### PR TITLE
Fixes "400: Bad Request" error.

### DIFF
--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -3,7 +3,7 @@ const MessageBuilder = require("./builder");
 const snekfetch = require("snekfetch");
 const util = require("util");
 
-const ENDPOINT = "https://discordapp.com/api/v8/webhooks";
+const ENDPOINT = "https://discordapp.com/api/v7/webhooks";
 
 class Webhook {
     /**


### PR DESCRIPTION
There's no such thing as the Discord "V8" API, its the "V7".

V8: https://file.coffee/u/AiKlUd9Of.png
V7: https://file.coffee/u/C43nE_o2f.png

This issue is detailed in: #59